### PR TITLE
Unable to use beds bug

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -352,6 +352,7 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 
 		if (bed->trySleep(player)) {
 			player->setBedItem(bed);
+			bed->sleep(player);
 			//g_game.sendOfflineTrainingDialog(player);
 		}
 


### PR DESCRIPTION
Fixed bug where beds did not work when clicking them.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.


**Protocol version**
7.72/8.60

### Changes Proposed

1 Issue where the usage of beds inside owned houses did not work


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
