### PR TITLE
Disable load XML of stages

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -120,7 +120,7 @@ ExperienceStages loadLuaStages(lua_State* L)
 	return stages;
 }
 
-ExperienceStages loadXMLStages()
+/*ExperienceStages loadXMLStages()
 {
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file("data/XML/stages.xml");
@@ -128,7 +128,7 @@ ExperienceStages loadXMLStages()
 		printXMLError("Error - loadXMLStages", "data/XML/stages.xml", result);
 		return {};
 	}
-
+	
 	ExperienceStages stages;
 	for (auto stageNode : doc.child("stages").children()) {
 		if (strcasecmp(stageNode.name(), "config") == 0) {
@@ -161,7 +161,7 @@ ExperienceStages loadXMLStages()
 	std::sort(stages.begin(), stages.end());
 	return stages;
 }
-
+*/
 }
 
 bool ConfigManager::load()
@@ -309,7 +309,7 @@ bool ConfigManager::load()
 	integer[DEPOT_FREE_LIMIT] = getGlobalNumber(L, "depotFreeLimit", 2000);
 	integer[DEPOT_PREMIUM_LIMIT] = getGlobalNumber(L, "depotPremiumLimit", 10000);
 
-	expStages = loadXMLStages();
+	/*expStages = loadXMLStages(); */
 	if (expStages.empty()) {
 		expStages = loadLuaStages(L);
 	} else {
@@ -321,7 +321,7 @@ bool ConfigManager::load()
 	lua_close(L);
 
 	return true;
-}
+} 
 
 bool ConfigManager::reload()
 {


### PR DESCRIPTION
Server checks Stages.xml at startup and displays a warning that it should use LUA instead.
Maybe not the best fix, but it works.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.


**Protocol version**
7.72
### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** Did a fast fix to disable load of stages.xml at startup, and instead use config.lua stages.
As the server console kept warning about useing XML is outdated.
This is also followed by removing stages.xml file in XML folder<!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
