### PR TITLE
Fix for ghostmode logout crash

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -607,6 +607,8 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 	size_t i = 0;
 	for (Creature* spectator : spectators) {
 		if (Player* player = spectator->getPlayer()) {
+			if (!player->canSeeCreature(creature))
+				continue;
 			player->sendRemoveTileCreature(creature, tilePosition, oldStackPosVector[i++]);
 		}
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -607,9 +607,9 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 	size_t i = 0;
 	for (Creature* spectator : spectators) {
 		if (Player* player = spectator->getPlayer()) {
-			if (!player->canSeeCreature(creature))
-				continue;
-			player->sendRemoveTileCreature(creature, tilePosition, oldStackPosVector[i++]);
+			if (player->canSeeCreature(creature)) {
+				player->sendRemoveTileCreature(creature, tilePosition, oldStackPosVector[i++]);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix for client crash when someone is in ghostmode and logging out nearby.
Help from @Roddett

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.


**Protocol version**
7.72

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Client crash when logging out in Ghostmode

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
