### PR TITLE
adding compatibility to 772 otbm version (version = 1)

### DIFF
--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -126,6 +126,7 @@ bool IOMap::loadMap(Map* map, const std::string& fileName)
 			std::cout << "[Warning - IOMap::loadMap] This map needs an updated items.otb." << std::endl;
 		}
 
+        Item::setMapVersion(root_header.version);
 		std::cout << "> Map size: " << root_header.width << "x" << root_header.height << '.' << std::endl;
 		map->width = root_header.width;
 		map->height = root_header.height;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -36,6 +36,7 @@ extern Spells* g_spells;
 extern Vocations g_vocations;
 
 Items Item::items;
+uint32_t Item::mapVersion = 1; //default map version for 7.72
 
 Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/)
 {
@@ -141,7 +142,17 @@ Item* Item::CreateItem(PropStream& propStream)
 			break;
 	}
 
-	return Item::CreateItem(id, 0);
+    const ItemType& iType = items[id];
+    unsigned char count = 0;
+    if(mapVersion == 0) {
+        if(iType.stackable || iType.isSplash() || iType.isFluidContainer()) {
+            if(!propStream.read<uint8_t>(count)){
+                return nullptr;
+            }
+        }
+    }
+
+    return Item::CreateItem(id, count);
 }
 
 Item::Item(const uint16_t type, uint16_t count /*= 0*/) :

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -143,10 +143,10 @@ Item* Item::CreateItem(PropStream& propStream)
 	}
 
     const ItemType& iType = items[id];
-    unsigned char count = 0;
-    if(mapVersion == 0) {
-        if(iType.stackable || iType.isSplash() || iType.isFluidContainer()) {
-            if(!propStream.read<uint8_t>(count)){
+    uint8_t count = 0;
+    if (mapVersion == 0) {
+        if (iType.stackable || iType.isSplash() || iType.isFluidContainer()) {
+            if (!propStream.read<uint8_t>(count)) {
                 return nullptr;
             }
         }

--- a/src/item.h
+++ b/src/item.h
@@ -1038,6 +1038,10 @@ class Item : virtual public Thing
 			return !parent || parent->isRemoved();
 		}
 
+        static void setMapVersion(uint32_t n) {
+            mapVersion = n;
+        }
+
 	protected:
 		Cylinder* parent = nullptr;
 
@@ -1053,6 +1057,8 @@ class Item : virtual public Thing
 		uint8_t count = 1; // number of stacked items
 
 		bool loadedFromMap = false;
+
+        static uint32_t mapVersion;
 
 		//Don't add variables here, use the ItemAttribute class.
 };

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -433,12 +433,19 @@ bool Items::loadFromOtb(const std::string& file)
 				//not used
 				iType.type = ITEM_TYPE_TELEPORT;
 				break;
+            case ITEM_GROUP_CHARGES:
+                iType.type = ITEM_TYPE_RUNE;
+            break;
 			case ITEM_GROUP_NONE:
 			case ITEM_GROUP_GROUND:
 			case ITEM_GROUP_SPLASH:
 			case ITEM_GROUP_FLUID:
-			case ITEM_GROUP_CHARGES:
 			case ITEM_GROUP_DEPRECATED:
+            case ITEM_GROUP_AMMUNITION:
+            case ITEM_GROUP_ARMOR:
+            case ITEM_GROUP_WEAPON:
+            case ITEM_GROUP_WRITEABLE:
+            case ITEM_GROUP_KEY:
 				break;
 			default:
 				return false;

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -435,7 +435,7 @@ bool Items::loadFromOtb(const std::string& file)
 				break;
             case ITEM_GROUP_CHARGES:
                 iType.type = ITEM_TYPE_RUNE;
-            break;
+                break;
 			case ITEM_GROUP_NONE:
 			case ITEM_GROUP_GROUND:
 			case ITEM_GROUP_SPLASH:


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.


**Protocol version**
7.72

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This pull-request adds retrocompatibility to 7.6 .otbm map version (version = 1). 
The changes are basically reading properly the count variable after splashes/fluidcontainers and stackables when the otbm version = 1. Also, adds the reading os ITEM_GROUP on switch-case statement while reading items.otb 

**Issues addressed:** <!-- Write here the issue number, if any. -->
#118 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
